### PR TITLE
Import default certificates on first launch

### DIFF
--- a/Feather/Backend/Storage/Feather.xcdatamodeld/Feather.xcdatamodel/contents
+++ b/Feather/Backend/Storage/Feather.xcdatamodeld/Feather.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AltSource" representedClassName="AltSource" syncable="YES" codeGenerationType="class">
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconURL" optional="YES" attributeType="URI"/>
@@ -10,6 +10,7 @@
     <entity name="CertificatePair" representedClassName="CertificatePair" syncable="YES" codeGenerationType="class">
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="expiration" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isDefault" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="nickname" optional="YES" attributeType="String"/>
         <attribute name="password" optional="YES" attributeType="String"/>
         <attribute name="ppQCheck" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Feather/Backend/Storage/Storage+Certificate.swift
+++ b/Feather/Backend/Storage/Storage+Certificate.swift
@@ -17,6 +17,7 @@ extension Storage {
 		nickname: String? = nil,
 		ppq: Bool = false,
 		expiration: Date,
+		isDefault: Bool = false,
 		completion: @escaping (Error?) -> Void
 	) {
 		let generator = UIImpactFeedbackGenerator(style: .light)
@@ -28,6 +29,7 @@ extension Storage {
 		new.ppQCheck = ppq
 		new.expiration = expiration
 		new.nickname = nickname
+		new.isDefault = isDefault
 		Storage.shared.revokagedCertificate(for: new)
 		saveContext()
 		generator.impactOccurred()

--- a/Feather/FeatherApp.swift
+++ b/Feather/FeatherApp.swift
@@ -151,6 +151,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 		_createPipeline()
 		_createDocumentsDirectories()
 		ResetView.clearWorkCache()
+		_addDefaultCertificates()
 		return true
 	}
 	
@@ -189,6 +190,40 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 		
 		for url in directories {
 			try? fileManager.createDirectoryIfNeeded(at: url)
+		}
+	}
+	
+	private func _addDefaultCertificates() {
+		if
+			UserDefaults.standard.bool(forKey: "feather.didImportDefaultCertificates") == false,
+			let p12Url = Bundle.main.url(forResource: "cert", withExtension: "p12"),
+			let provisionUrl = Bundle.main.url(forResource: "cert", withExtension: "mobileprovision"),
+			let passwordUrl = Bundle.main.url(forResource: "cert", withExtension: "txt")
+		{
+			do {
+				let password = try String(contentsOf: passwordUrl, encoding: .utf8)
+				
+				FR.handleCertificateFiles(
+					p12URL: p12Url,
+					provisionURL: provisionUrl,
+					p12Password: password,
+					certificateName: "Imported Certificate",
+					isDefault: true
+				) { err in
+					if let err {
+						DispatchQueue.main.async {
+							UIAlertController.showAlertWithOk(
+								title: "Failed to import",
+								message: err.localizedDescription
+							)
+						}
+					} else {
+						UserDefaults.standard.set(true, forKey: "feather.didImportDefaultCertificates")
+					}
+				}
+			} catch {
+				print("Failed to read cert password: \(error)")
+			}
 		}
 	}
 }

--- a/Feather/Utilities/FR.swift
+++ b/Feather/Utilities/FR.swift
@@ -72,6 +72,7 @@ enum FR {
 		provisionURL: URL,
 		p12Password: String,
 		certificateName: String = "",
+		isDefault: Bool = false,
 		completion: @escaping (Error?) -> Void
 	) {
 		Task.detached {
@@ -79,7 +80,8 @@ enum FR {
 				key: p12URL,
 				provision: provisionURL,
 				password: p12Password,
-				nickname: certificateName.isEmpty ? nil : certificateName
+				nickname: certificateName.isEmpty ? nil : certificateName,
+				isDefault: isDefault
 			)
 			
 			do {

--- a/Feather/Utilities/Handlers/CertificateFileHandler.swift
+++ b/Feather/Utilities/Handlers/CertificateFileHandler.swift
@@ -16,6 +16,7 @@ final class CertificateFileHandler: NSObject {
 	private let _provision: URL
 	private let _keyPassword: String?
 	private let _certNickname: String?
+	private let _isDefault: Bool
 	
 	private var _certPair: Certificate?
 	
@@ -23,12 +24,14 @@ final class CertificateFileHandler: NSObject {
 		key: URL,
 		provision: URL,
 		password: String? = nil,
-		nickname: String? = nil
+		nickname: String? = nil,
+		isDefault: Bool = false
 	) {
 		self._key = key
 		self._provision = provision
 		self._keyPassword = password
 		self._certNickname = nickname
+		self._isDefault = isDefault
 		
 		_certPair = CertificateReader(provision).decoded
 		
@@ -38,7 +41,7 @@ final class CertificateFileHandler: NSObject {
 	func copy() async throws {
 		guard
 			(_certPair != nil)
-		else  {
+		else {
 			throw CertificateFileHandlerError.certNotValid
 		}
 		
@@ -56,7 +59,8 @@ final class CertificateFileHandler: NSObject {
 			password: _keyPassword,
 			nickname: _certNickname,
 			ppq: _certPair?.PPQCheck ?? false,
-			expiration: _certPair?.ExpirationDate ?? Date()
+			expiration: _certPair?.ExpirationDate ?? Date(),
+			isDefault: _isDefault
 		) { _ in
 			Logger.misc.info("[\(self._uuid)] Added to database")
 		}

--- a/Feather/Views/Settings/Certificates/CertificatesView.swift
+++ b/Feather/Views/Settings/Certificates/CertificatesView.swift
@@ -102,8 +102,10 @@ extension CertificatesView {
 			)
 			.contextMenu {
 				_contextActions(for: cert)
-				Divider()
-				_actions(for: cert)
+				if cert.isDefault != true {
+					Divider()
+					_actions(for: cert)
+				}
 			}
 			.transaction {
 				$0.animation = nil


### PR DESCRIPTION
## Summary
- add a Core Data flag to track whether a certificate pair is the default bundle
- import bundled certificate assets on first launch and mark them as default
- prevent deleting default certificates from the UI context menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd78fbb134832b8d931b42467bc2ae